### PR TITLE
WebSockets in Apache

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -8,6 +8,7 @@
     with_items:
       - proxy
       - proxy_http
+      - proxy_wstunnel
       - rewrite
 
   - name: Configure apache proxy

--- a/roles/apache/templates/proxy.conf.j2
+++ b/roles/apache/templates/proxy.conf.j2
@@ -2,6 +2,9 @@
   ServerName {{ apache_url }}
   ProxyPreserveHost On
   RewriteEngine on
+  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+  RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
+  RewriteRule .* ws://localhost:{{ meteor_port }}%{REQUEST_URI} [P]
   ProxyPass / http://localhost:{{ meteor_port }}/
   ProxyPassReverse / http://localhost:{{ meteor_port }}/
 </VirtualHost>


### PR DESCRIPTION
This enables meteor's websockets to work with the apache proxy. I'm not really sure how to tell if it's working, but I don't see the websocket errors in the console on eidr-dev anymore.
