### PR TITLE
Update meteor bundle to build and fix redeployments after an import error

### DIFF
--- a/roles/grid/tasks/main.yml
+++ b/roles/grid/tasks/main.yml
@@ -68,6 +68,5 @@
 
   - name: Restart grid process
     supervisorctl: name="grid" state=restarted
-    when: grid.changed
     sudo: yes
     sudo_user: root


### PR DESCRIPTION
This should fix grid#213 and also updates from meteor bundle which has apparently been replaced with meteor build.
